### PR TITLE
Add pytest setup and value parsing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,16 @@ Este é um programa de console, desenvolvido em Python, para gerenciamento de fi
     python src/financas.py
     ```
 
+## ✅ Como Executar os Testes
+
+1.  Certifique-se de ter instalado as dependências:
+    ```bash
+    pip install -r requirements.txt
+    ```
+2.  Rode o pytest na raiz do projeto:
+    ```bash
+    pytest
+    ```
+
 ---
 *Este projeto foi desenvolvido com a ajuda do Parceiro de Programação da Google.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dateutil==2.9.0.post0
 pytz==2025.2
 six==1.17.0
 tzdata==2025.2
+
+pytest==8.1.1

--- a/src/financas.py
+++ b/src/financas.py
@@ -201,8 +201,12 @@ def aguardar_enter():
     input("\nPressione Enter para voltar ao menu...")
 def obter_valor_float(mensagem):
     while True:
-        try: return float(input(mensagem).replace(',', '.'))
-        except ValueError: print("❌ Erro: Por favor, digite um número válido.")
+        entrada = input(mensagem)
+        try:
+            limpa = entrada.replace('.', '').replace(',', '.')
+            return float(limpa)
+        except ValueError:
+            print("❌ Erro: Por favor, digite um número válido.")
 def obter_valor_int(mensagem):
     while True:
         try: return int(input(mensagem))

--- a/tests/test_obter_valor_float.py
+++ b/tests/test_obter_valor_float.py
@@ -1,0 +1,11 @@
+import src.financas as financas
+
+
+def test_obter_valor_float_com_virgula(monkeypatch):
+    monkeypatch.setattr('builtins.input', lambda _: "500,00")
+    assert financas.obter_valor_float("Valor: ") == 500.0
+
+
+def test_obter_valor_float_milhar(monkeypatch):
+    monkeypatch.setattr('builtins.input', lambda _: "1.234,56")
+    assert financas.obter_valor_float("Valor: ") == 1234.56


### PR DESCRIPTION
## Summary
- refine `obter_valor_float` to handle thousands separators
- add pytest as a dependency
- document how to run the tests
- add tests for `obter_valor_float`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da06dd7f483229f5d947a327a559e