### PR TITLE
Fix cleanup in TestAdicionarMeta

### DIFF
--- a/tests/test_financas.py
+++ b/tests/test_financas.py
@@ -9,6 +9,9 @@ import src.financas as financas
 
 class TestAdicionarMeta(unittest.TestCase):
     def setUp(self):
+        self.original_data_dir = financas.DATA_DIR
+        self.original_arquivo_metas = financas.ARQUIVO_METAS
+
         self.temp_dir = tempfile.TemporaryDirectory()
         financas.DATA_DIR = self.temp_dir.name
         financas.ARQUIVO_METAS = os.path.join(financas.DATA_DIR, 'metas.csv')
@@ -16,6 +19,8 @@ class TestAdicionarMeta(unittest.TestCase):
 
     def tearDown(self):
         self.temp_dir.cleanup()
+        financas.DATA_DIR = self.original_data_dir
+        financas.ARQUIVO_METAS = self.original_arquivo_metas
 
     def test_adicionar_meta(self):
         financas.adicionar_meta('Viagem', 5000.0, '2025-12')


### PR DESCRIPTION
## Summary
- retain original paths for `financas.DATA_DIR` and `financas.ARQUIVO_METAS`
- restore them in `tearDown`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dc52bbc3c83229948ed6cf6a140bf