### PR TITLE
Add retry test for obter_valor_float

### DIFF
--- a/tests/test_obter_valor_float.py
+++ b/tests/test_obter_valor_float.py
@@ -9,3 +9,16 @@ def test_obter_valor_float_com_virgula(monkeypatch):
 def test_obter_valor_float_milhar(monkeypatch):
     monkeypatch.setattr('builtins.input', lambda _: "1.234,56")
     assert financas.obter_valor_float("Valor: ") == 1234.56
+
+
+def test_obter_valor_float_retorna_apos_erro(monkeypatch, capsys):
+    from unittest.mock import Mock
+
+    input_mock = Mock(side_effect=["abc", "10,00"])
+    monkeypatch.setattr('builtins.input', input_mock)
+
+    resultado = financas.obter_valor_float("Valor: ")
+    capturado = capsys.readouterr()
+
+    assert resultado == 10.0
+    assert capturado.out.count("❌ Erro: Por favor, digite um número válido.") == 1


### PR DESCRIPTION
## Summary
- extend `test_obter_valor_float.py` to cover retry logic with invalid input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e77b1bd24832295cf98f450035546